### PR TITLE
Add PHP 8.4 and 8.5 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     name: PHP ${{ matrix.php }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-02-17
+### Added
+- PHP 8.4 support
+- PHP 8.5 support
+
 ## [2.4.0] - 2023-12-11
 ### Added
 - PHP 8.3 support

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Validation of Estonian company registry code
 
 # Compatibility
 
-PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3
+PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5
 
 # Maintainability
 


### PR DESCRIPTION
## Summary
This PR adds support for PHP 8.4 and 8.5 to the project, expanding compatibility with the latest PHP versions.

## Changes
- Updated CI/CD workflow to test against PHP 8.4 and 8.5
- Updated README compatibility documentation to reflect support for PHP 8.4 and 8.5
- Added changelog entry for version 2.5.0 documenting the new PHP version support

## Details
The project now officially supports PHP versions 7.0 through 8.5, with continuous integration testing configured for all supported versions.

https://claude.ai/code/session_018CEjiZaZLjRQXguk1Gek4h